### PR TITLE
Add markdown and copy to clipboard support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ typings/
 
 # next.js build output
 .next
+
+# editor ide configs
+.idea

--- a/app.js
+++ b/app.js
@@ -87,18 +87,50 @@ const template = params => `
   This Code of Conduct is adapted from <a href="https://dev.to/code-of-conduct">dev.to</a>.
 </p>
 `
-
-document.getElementById('settings').addEventListener('submit', e => {
+const appState = {
+  params: {}
+}
+const copyButton = document.getElementById('copy')
+const result = document.getElementById('result')
+const settings = document.getElementById('settings')
+const main = document.getElementById('main')
+settings.addEventListener('submit', e => {
   e.preventDefault()
 
-  let params = {}
+
   Array.prototype.slice.call(document.getElementsByClassName('data')).forEach(
-    node => { params[node.getAttribute('id')] = node.type === 'checkbox' ? node.checked : node.value  }
+    node => { appState.params[node.getAttribute('id')] = node.type === 'checkbox' ? node.checked : node.value  }
   )
 
-  document.getElementById('main').classList.add('done')
-  document.getElementById('result').innerHTML = template(params)
+  main.classList.add('done')
+  new ClipboardJS('.copy-to-clipboard');
+  const turndownService = new TurndownService()
+  const html = template(appState.params)
+  const markdown = turndownService.turndown(html)
+  appState.output = {
+    html,
+    markdown
+  }
+  copyButton.dataset.clipboardText = html
+  result.innerHTML = html
 })
+
+Array.prototype.slice.call(document.querySelectorAll('.export-options input')).forEach(
+  node => { node.addEventListener('change', (e) => {
+    const { value: exportType } = e.target
+    const { output } = appState
+    switch (exportType) {
+      case "markdown":
+        copyButton.dataset.clipboardText = output.markdown
+        result.innerHTML = `<code>${output.markdown.replace(/\n/g, '<br>')}</code>`
+        break;
+      case "html":
+      default:
+        copyButton.dataset.clipboardText = output.html
+        result.innerHTML = output.html
+    }
+  })}
+)
 
 document.getElementById('again').addEventListener('click', () => window.location.reload())
 document.getElementById('print').addEventListener('click', () => window.print())

--- a/index.html
+++ b/index.html
@@ -9,6 +9,9 @@
 
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.min.css">
     <link rel="stylesheet" href="style.css">
+
+    <script src="https://unpkg.com/turndown/dist/turndown.js"></script>
+    <script src="https://unpkg.com/clipboard@2/dist/clipboard.min.js"></script>
   </head>
   <body>
     <header>
@@ -59,7 +62,7 @@
             Attacking tastes
           </label>
           <div class="group">
-            <label for="name">Your organization name:</label>
+            <label for="org-name">Your organization name:</label>
             <input type="text" id="org-name" placeholder="The Unicorn Speedshop" class="field data" required>
           </div>
           <div class="group">
@@ -73,6 +76,13 @@
         <div class="pillbox noprint">
           <span>Here you go!</span>
           <button id="print">Print this</button>
+          <button id="copy" class="copy-to-clipboard">Copy to clipboard</button>
+          <div class="export-options">
+            <input type="radio" id="html" name="export" value="html" checked>
+            <label for="html">HTML</label>
+            <input type="radio" id="markdown" name="export" value="markdown">
+            <label for="markdown">Markdown</label>
+          </div>
         </div>
         <div class="print" id="result"></div>
         <button class="noprint" type="button" id="again">Start over</button>

--- a/style.css
+++ b/style.css
@@ -148,3 +148,7 @@ main.done .controls {
 .pillbox > * {
   margin: 10px;
 }
+
+.export-options label{
+  display: inline-block;
+}


### PR DESCRIPTION
Result page has radio button options to choose HTML or Markdown output.

A Copy to clipboard button is added next to Print This button to copy code of conduct output.
